### PR TITLE
サーバーコンポーネントとクライアントコンポーネントを分離

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import Title from '@/components/Title';
 export default function Home() {
   return (
     <>
-      <Title text='水瀬いのりライブチェッカー' titleFlag={true} />
+      <Title text='水瀬いのりライブチェッカー' titleFlag={false} />
       <p className='mb-12 font-sans pb-12 text-base'>
         自分がまだライブで聴いたことのない曲を一覧で表示することができます。
         <br />

--- a/src/components/Live.tsx
+++ b/src/components/Live.tsx
@@ -1,0 +1,73 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import Button from '@/components/Button';
+import Title from '@/components/Title';
+import CheckBox from '@/components/CheckBox';
+import useFetch from '@/hooks/useFetch';
+import { useAtom } from 'jotai';
+import { LiveDataProps } from '@/types/types';
+import { selectedLivesAtom } from '@/state/atoms';
+import Loading from '@/components/Loading';
+
+const Live: React.FC = () => {
+  const { data: liveLists, isLoading, isError } = useFetch<LiveDataProps[]>({ url: 'api/live' });
+  const [selectedLives, setSelectedLives] = useAtom(selectedLivesAtom);
+
+  const handleCheckboxChange = (id: number, checked: boolean) => {
+    const updatedSelectedLives = checked
+      ? [...selectedLives, id]
+      : selectedLives.filter((selectedId) => selectedId !== id);
+    setSelectedLives(updatedSelectedLives);
+  };
+
+  useEffect(() => {
+    setSelectedLives([]);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('selectedLives', JSON.stringify(selectedLives));
+  }, [selectedLives]);
+
+  if (isLoading) return <Loading />;
+  if (isError) return;
+  if (!liveLists) return;
+
+  const inoriMinaseLive = liveLists.filter((live) => live.live_type_id === 1);
+  const townMeetingLive = liveLists.filter((live) => live.live_type_id === 2);
+
+  return (
+    <>
+      <Title text='水瀬いのり個人名義' titleFlag={false} />
+      {inoriMinaseLive &&
+        inoriMinaseLive.map((liveList) => (
+          <div key={liveList.id} className='my-6'>
+            <CheckBox
+              id={liveList.id}
+              label={liveList.name}
+              onCheckboxChange={handleCheckboxChange}
+            />
+          </div>
+        ))}
+      <Title text='町民集会' titleFlag={false} />
+      {townMeetingLive &&
+        townMeetingLive.map((liveList) => (
+          <div key={liveList.id}>
+            <CheckBox
+              id={liveList.id}
+              label={liveList.name}
+              onCheckboxChange={handleCheckboxChange}
+            />
+          </div>
+        ))}
+      <Button
+        text='会場を選択する'
+        color='primary'
+        href='/venue'
+        disabled={selectedLives.length === 0}
+      />
+      <Button text='最初に戻る' color='secondary' href='/' />
+    </>
+  );
+};
+
+export default Live;

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { ResultDataProps } from '@/types/types';
+import Button from '@/components/Button';
+import useFetch from '@/hooks/useFetch';
+import { useAtom } from 'jotai';
+import { selectedVenuesAtom } from '@/state/atoms';
+import Loading from './Loading';
+import { useEffect, useState } from 'react';
+
+const Result: React.FC = () => {
+  const [selectedVenues, setSelectedVenues] = useAtom(selectedVenuesAtom);
+  const [shouldFetch, setShouldFetch] = useState(false);
+
+  const {
+    data: resultLists,
+    isLoading,
+    isError,
+  } = useFetch<ResultDataProps[]>({
+    url: shouldFetch ? `api/result?venue_id=${selectedVenues.join(',')}` : null,
+  });
+
+  // localStorageからselectedVenuesを読み込む
+  useEffect(() => {
+    const savedSelectedVenues = localStorage.getItem('selectedVenues');
+    if (savedSelectedVenues) {
+      setSelectedVenues(JSON.parse(savedSelectedVenues));
+      const parsedVenues = JSON.parse(savedSelectedVenues);
+      // selectedLivesがある場合のみフェッチを許可
+      setShouldFetch(parsedVenues.length > 0);
+    }
+  }, []);
+
+  if (isLoading) return <Loading />;
+  if (isError || !resultLists) return <Button text='最初に戻る' color='primary' href='/' />;
+
+  const songsCount = resultLists.length;
+
+  return (
+    <>
+      <p className='mr-2 text-xl font-medium'>聴いたことがない曲は{songsCount}曲です</p>
+      <ul>
+        {resultLists.map((song) => (
+          <li key={song.id} className='py-1'>
+            {song.title}
+          </li>
+        ))}
+      </ul>
+      <Button text='会場選択に戻る' color='primary' href='/venue' />
+      <Button text='最初に戻る' color='secondary' href='/' />
+    </>
+  );
+};
+
+export default Result;

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { TitleProps } from '@/types/types';
+
+const Title: React.FC<TitleProps> = ({ text, titleFlag }) => {
+  return (
+    <div>
+      <h2
+        className={`font-sans font-normal w-full ${
+          titleFlag === true ? 'text-4xl mb-4 mt-8' : 'text-3xl my-8'
+        }`}
+        key={text}
+      >
+        {text}
+      </h2>
+    </div>
+  );
+};
+
+export default Title;

--- a/src/components/Venue.tsx
+++ b/src/components/Venue.tsx
@@ -1,0 +1,89 @@
+'use client';
+import { useAtom } from 'jotai';
+import { GroupedVenues, VenueDataProps } from '@/types/types';
+import Button from '@/components/Button';
+import Title from '@/components/Title';
+import Checkbox from '@/components/CheckBox';
+import { selectedLivesAtom, selectedVenuesAtom } from '@/state/atoms';
+import useFetch from '@/hooks/useFetch';
+import { useEffect, useState } from 'react';
+import Loading from '@/components/Loading';
+
+const groupVenuesByLiveName = (venues: VenueDataProps[]): GroupedVenues => {
+  return venues.reduce<GroupedVenues>((acc, venue) => {
+    (acc[venue.live_name] = acc[venue.live_name] || []).push(venue);
+    return acc;
+  }, {});
+};
+
+const Venue: React.FC = () => {
+  const [selectedLives, setSelectedLives] = useAtom(selectedLivesAtom);
+  const [selectedVenues, setSelectedVenues] = useAtom(selectedVenuesAtom);
+  const [shouldFetch, setShouldFetch] = useState(false);
+
+  // selectedLivesが設定された後にuseFetchを呼び出す
+  const {
+    data: venueLists,
+    isLoading,
+    isError,
+  } = useFetch<VenueDataProps[]>({
+    url: shouldFetch ? `api/venue?id=${selectedLives.join(',')}` : null,
+  });
+
+  const handleCheckboxChange = (id: number, checked: boolean) => {
+    const updatedSelectedVenues = checked
+      ? [...selectedVenues, id]
+      : selectedVenues.filter((selectedId) => selectedId !== id);
+    setSelectedVenues(updatedSelectedVenues);
+  };
+
+  useEffect(() => {
+    setSelectedVenues([]);
+  }, []);
+
+  // localStorageからselectedLivesを読み込む
+  useEffect(() => {
+    const savedSelectedLives = localStorage.getItem('selectedLives');
+    if (savedSelectedLives) {
+      const parsedLives = JSON.parse(savedSelectedLives);
+      setSelectedLives(parsedLives);
+
+      // selectedLivesがある場合のみフェッチを許可
+      setShouldFetch(parsedLives.length > 0);
+    }
+  }, []);
+
+  // selectedVenuesが更新されたら、localStorageに保存する
+  useEffect(() => {
+    localStorage.setItem('selectedVenues', JSON.stringify(selectedVenues));
+  }, [selectedVenues]);
+
+  const groupedVenues = venueLists ? groupVenuesByLiveName(venueLists) : {};
+
+  if (isLoading) return <Loading />;
+  if (isError || !venueLists) return <Button text='最初に戻る' color='primary' href='/' />;
+
+  return (
+    <>
+      {Object.keys(groupedVenues).map((live_name, index) => (
+        <div key={live_name + index}>
+          <Title text={live_name} titleFlag={true} />
+          {groupedVenues[live_name].map((venue) => (
+            <div key={venue.id} className='my-6'>
+              <Checkbox id={venue.id} label={venue.name} onCheckboxChange={handleCheckboxChange} />
+            </div>
+          ))}
+        </div>
+      ))}
+      <Button
+        text='結果を見る'
+        color='primary'
+        href='/result'
+        disabled={selectedVenues.length === 0}
+      />
+      <Button text='ライブ選択に戻る' color='secondary' href='/live' />
+    </>
+  );
+};
+
+export default Venue;


### PR DESCRIPTION
## 概要
- 読み込み時になんも表示されないのはあれなので、サーバーコンポーネントとクライアントコンポーネントを分離した
- ローカルストレージを使いリロード時に値を参照することで、何も見えなくなる画面をなくした